### PR TITLE
Fix for ENOENT problem

### DIFF
--- a/gulp/tasks/clean.coffee
+++ b/gulp/tasks/clean.coffee
@@ -2,5 +2,5 @@ gulp = require('gulp')
 del = require('del')
 config = require('../config')
 
-gulp.task 'clean', ->
-  del([config.publicDir])
+gulp.task 'clean', (cb) ->
+  del([config.publicDir], cb)


### PR DESCRIPTION
This fix resolves problem with crashing "copy" task which has pipe conflict with cleaning task.