### PR TITLE
Add refresh behavior to update separate modules views data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Add refresh behavior to update views data in separate modules
+([#145](https://github.com/fs/backbone-base/pull/145))
 - Change Jade template on Pug
 ([#146](https://github.com/fs/backbone-base/pull/146))
 - Show spinner while the app is sending request to server

--- a/app/src/behaviors/refresh.js
+++ b/app/src/behaviors/refresh.js
@@ -1,0 +1,38 @@
+import Marionette from 'backbone.marionette';
+import App from 'application';
+import Session from 'services/session';
+import { props } from 'decorators';
+
+@props({
+  modelEvents: {
+    'change': 'render'
+  }
+})
+export default class RefreshBehavior extends Marionette.Behavior {
+  initialize() {
+    this.listenTo(App.vent, 'data:refresh', this.fetchData);
+  }
+
+  render() {
+    this.view.render();
+  }
+
+  fetchData() {
+    if (this.view.collection) {
+      this.view.collection.fetch();
+    }
+
+    if (this.view.model) {
+      this.view.model.fetch().then(this.saveSession.bind(this));
+    }
+  }
+
+  saveSession() {
+    const currentModelPrototype = this.view.model.constructor.prototype;
+    const sessionModelPrototype = Session.currentUser().constructor.prototype;
+
+    if (currentModelPrototype === sessionModelPrototype) {
+      Session.save();
+    }
+  }
+}


### PR DESCRIPTION
This PR adds Marionette.Behavior that allows to update views with new fetched data when you call the corresponding event 