### PR TITLE
Add gitattributes to avoid merge conflicts associated with CHANGELOG

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Add .gitattributes to avoid merge conflicts
+([#154](https://github.com/fs/backbone-base/pull/154))
 - Upgrade dependencies
 ([#153](https://github.com/fs/backbone-base/pull/153))
 - Rewrite class props via core-decorators "mixin" decorator


### PR DESCRIPTION
Upon merging a single merge request, all other unmerged PRs immediately have merge conflicts because of CHANGELOG.md. What I propose is to add .gitattributes file with CHANGELOG merge=union line inside. Instead of leaving conflicts the union merge option will resolve conflicts favouring both side of the lines.